### PR TITLE
Introduce strong types, slight algorithm changes

### DIFF
--- a/lidar/CMakeLists.txt
+++ b/lidar/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package()
 ## Build talker and listener
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-add_executable(lidar src/deflection.cpp src/main.cpp)
+add_executable(lidar src/math.cpp src/deflection.cpp src/main.cpp)
 target_link_libraries(lidar ${catkin_LIBRARIES})
 add_dependencies(lidar beginner_tutorials_generate_messages_cpp)
 

--- a/lidar/include/deflection.hpp
+++ b/lidar/include/deflection.hpp
@@ -3,5 +3,6 @@
 #include "reading.hpp"
 
 double calculate_deflection_component(const SensorReading& reading);
+
 double calculate_deflection(const sensor_msgs::LaserScan::ConstPtr& message);
 

--- a/lidar/include/deflection.hpp
+++ b/lidar/include/deflection.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "reading.hpp"
+#include "math.hpp"
 
-double calculate_deflection_component(const SensorReading& reading);
+Degree calculate_deflection_component(const SensorReading& reading);
 
-double calculate_deflection(const sensor_msgs::LaserScan::ConstPtr& message);
+Degree calculate_deflection(const sensor_msgs::LaserScan::ConstPtr& message);
 

--- a/lidar/include/deflection.hpp
+++ b/lidar/include/deflection.hpp
@@ -2,9 +2,6 @@
 
 #include "reading.hpp"
 
-double rad2deg(double radians);
-double deg2rad(double degrees);
-
 double calculate_deflection_component(const SensorReading& reading);
 double calculate_deflection(const sensor_msgs::LaserScan::ConstPtr& message);
 

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utility.hpp"
+
 struct Degree;
 struct Radian;
 
@@ -15,6 +17,7 @@ struct Degree final {
 
         bool operator<(const Degree& other) const;
         bool operator>(const Degree& other) const;
+        bool operator==(const Degree& other) const;
 
         Radian as_radian() const;
         double as_double() const;
@@ -32,6 +35,10 @@ struct Radian final {
 
         Radian operator*(double scalar) const;
         Radian operator/(double scalar) const;
+        
+        bool operator<(const Radian& other) const;
+        bool operator>(const Radian& other) const;
+        bool operator==(const Radian& other) const;
         
         Degree as_degree() const;
         double as_double() const;

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -36,7 +36,7 @@ struct Radian final {
 
         Radian operator*(double scalar) const;
         Radian operator/(double scalar) const;
-        
+
         bool operator<(const Radian& other) const;
         bool operator>(const Radian& other) const;
         bool operator==(const Radian& other) const;

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -5,7 +5,7 @@ struct Radian;
 
 struct Degree final {
     public:
-        Degree(int value);
+        Degree(double value);
 
         Degree operator+(const Degree& other) const;
         Degree operator-(const Degree& other) const;
@@ -15,13 +15,12 @@ struct Degree final {
 
         bool operator<(const Degree& other) const;
         bool operator>(const Degree& other) const;
-        bool operator==(const Degree& other) const;
 
         Radian as_radian() const;
-        int as_int() const;
+        double as_double() const;
 
     private:
-        int m_inner;
+        double m_inner;
 };
 
 struct Radian final {
@@ -33,7 +32,7 @@ struct Radian final {
 
         Radian operator*(double scalar) const;
         Radian operator/(double scalar) const;
-
+        
         Degree as_degree() const;
         double as_double() const;
 

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -50,22 +50,22 @@ struct Radian final {
 
 struct Centimeter final {
     public:
-        Centimeter(double value);
+        Centimeter(int value);
 
         Centimeter operator+(const Centimeter& other) const;
         Centimeter operator-(const Centimeter& other) const;
 
-        Centimeter operator*(double scalar) const;
-        Centimeter operator/(double scalar) const;
+        Centimeter operator*(int scalar) const;
+        Centimeter operator/(int scalar) const;
         
         bool operator<(const Centimeter& other) const;
         bool operator>(const Centimeter& other) const;
         bool operator==(const Centimeter& other) const;
         
-        double as_double() const;
+        int as_int() const;
 
     private:
-        double m_inner;
+        int m_inner;
 };
 
 /**

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -11,7 +11,7 @@ struct Degree final {
         Degree(double value);
 
         Degree operator+(const Degree& other) const;
-        Degree operator-(const Degree& other) const;
+        Degree operator-() const;
         
         Degree operator*(double scalar) const;
         Degree operator/(double scalar) const;
@@ -32,7 +32,7 @@ struct Radian final {
         Radian(double value);
 
         Radian operator+(const Radian& other) const;
-        Radian operator-(const Radian& other) const;
+        Radian operator-() const;
 
         Radian operator*(double scalar) const;
         Radian operator/(double scalar) const;

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+/**
+ * Converts the number in radians in the interval [-pi/2, pi/2] 
+ * to degrees within the interval [-180, 180]. 
+ *
+ * This will also shift the angles around 180°, so that the 0° 
+ * mark is straight forward.
+ */
+double rad2deg(double radians);
+
+/**
+ * Converts the degrees on the interval [-180, 180] to to the
+ * interval [-pi/2, pi/2].
+ */
+double deg2rad(double degrees);
+

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -4,6 +4,7 @@
 
 struct Degree;
 struct Radian;
+struct Centimeter;
 
 struct Degree final {
     public:
@@ -41,6 +42,26 @@ struct Radian final {
         bool operator==(const Radian& other) const;
         
         Degree as_degree() const;
+        double as_double() const;
+
+    private:
+        double m_inner;
+};
+
+struct Centimeter final {
+    public:
+        Centimeter(double value);
+
+        Centimeter operator+(const Centimeter& other) const;
+        Centimeter operator-(const Centimeter& other) const;
+
+        Centimeter operator*(double scalar) const;
+        Centimeter operator/(double scalar) const;
+        
+        bool operator<(const Centimeter& other) const;
+        bool operator>(const Centimeter& other) const;
+        bool operator==(const Centimeter& other) const;
+        
         double as_double() const;
 
     private:

--- a/lidar/include/math.hpp
+++ b/lidar/include/math.hpp
@@ -1,5 +1,46 @@
 #pragma once
 
+struct Degree;
+struct Radian;
+
+struct Degree final {
+    public:
+        Degree(int value);
+
+        Degree operator+(const Degree& other) const;
+        Degree operator-(const Degree& other) const;
+        
+        Degree operator*(double scalar) const;
+        Degree operator/(double scalar) const;
+
+        bool operator<(const Degree& other) const;
+        bool operator>(const Degree& other) const;
+        bool operator==(const Degree& other) const;
+
+        Radian as_radian() const;
+        int as_int() const;
+
+    private:
+        int m_inner;
+};
+
+struct Radian final {
+    public:
+        Radian(double value);
+
+        Radian operator+(const Radian& other) const;
+        Radian operator-(const Radian& other) const;
+
+        Radian operator*(double scalar) const;
+        Radian operator/(double scalar) const;
+
+        Degree as_degree() const;
+        double as_double() const;
+
+    private:
+        double m_inner;
+};
+
 /**
  * Converts the number in radians in the interval [-pi/2, pi/2] 
  * to degrees within the interval [-180, 180]. 

--- a/lidar/include/reading.hpp
+++ b/lidar/include/reading.hpp
@@ -3,12 +3,13 @@
 #include <vector>
 #include <sensor_msgs/LaserScan.h>
 
+#include "math.hpp"
+
 struct SensorReading final {
     public:
-        int distance;
-        int angle;
-};
+        SensorReading(int dist, Degree ang) : distance{dist}, angle{ang} {}
 
-std::vector<SensorReading> 
-convert_readings(const sensor_msgs::LaserScan::ConstPtr& data);
+        int distance;
+        Degree angle;
+};
 

--- a/lidar/include/reading.hpp
+++ b/lidar/include/reading.hpp
@@ -7,9 +7,9 @@
 
 struct SensorReading final {
     public:
-        SensorReading(int dist, Degree ang) : distance{dist}, angle{ang} {}
+        SensorReading(Centimeter dist, Degree ang) : distance{dist}, angle{ang} {}
 
-        int distance;
+        Centimeter distance;
         Degree angle;
 };
 

--- a/lidar/include/utility.hpp
+++ b/lidar/include/utility.hpp
@@ -5,30 +5,31 @@ T operator-(const T& lhs, const T& rhs) {
     return lhs + -rhs;
 }
 
-template<typename T, typename U>
-U operator*(const T& lhs, const U& rhs) {
-    return rhs * lhs;
-}
+#define COMMUTATIVITY(op) \
+    template<typename T, typename U>\
+    U operator op (const T& lhs, const U& rhs) { return rhs * lhs; }
 
-template<typename T, typename U>
-void operator+=(T& lhs, const U& rhs) {
-    lhs = lhs + rhs;
-}
+COMMUTATIVITY(+);
+COMMUTATIVITY(*);
 
-template<typename T, typename U>
-void operator-=(T& lhs, const U& rhs) {
-    lhs = lhs - rhs;
-}
+#undef COMMUTATIVITY
 
-template<typename T, typename U>
-void operator*=(T& lhs, const U& rhs) {
-    lhs = lhs * rhs;
-}
+#define _CREATE_IDENTIFIER(a, b) a ## b
+#define CREATE_IDENTIFIER(a, b) _CREATE_IDENTIFIER(a, b) 
+#define ASSIGNMENT(op) \
+    template<typename T, typename U> \
+    void operator CREATE_IDENTIFIER(op, =) (T& lhs, const U& rhs) { \
+        lhs = lhs op rhs; \
+    }
 
-template<typename T, typename U>
-void operator/=(T& lhs, const U& rhs) {
-    lhs = lhs / rhs;
-}
+ASSIGNMENT(+);
+ASSIGNMENT(-);
+ASSIGNMENT(*);
+ASSIGNMENT(/);
+
+#undef ASSIGNMENT
+#undef CREATE_IDENTIFIER
+#undef _CREATE_IDENTIFIER
 
 template<typename T, typename U>
 bool operator<=(const T& lhs, const U& rhs) {

--- a/lidar/include/utility.hpp
+++ b/lidar/include/utility.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+template<typename T, typename U>
+void operator+=(T& lhs, const U& rhs) {
+    lhs = lhs + rhs;
+}
+
+template<typename T, typename U>
+void operator-=(T& lhs, const U& rhs) {
+    lhs = lhs - rhs;
+}
+
+template<typename T, typename U>
+void operator*=(T& lhs, const U& rhs) {
+    lhs = lhs * rhs;
+}
+
+template<typename T, typename U>
+void operator/=(T& lhs, const U& rhs) {
+    lhs = lhs / rhs;
+}

--- a/lidar/include/utility.hpp
+++ b/lidar/include/utility.hpp
@@ -19,3 +19,14 @@ template<typename T, typename U>
 void operator/=(T& lhs, const U& rhs) {
     lhs = lhs / rhs;
 }
+
+template<typename T, typename U>
+bool operator<=(const T& lhs, const U& rhs) {
+    return lhs < rhs || lhs == rhs;
+}
+
+template<typename T, typename U>
+bool operator>=(const T& lhs, const U& rhs) {
+    return lhs > rhs || lhs == rhs;
+}
+

--- a/lidar/include/utility.hpp
+++ b/lidar/include/utility.hpp
@@ -1,5 +1,15 @@
 #pragma once
 
+template<typename T>
+T operator-(const T& lhs, const T& rhs) {
+    return lhs + -rhs;
+}
+
+template<typename T, typename U>
+U operator*(const T& lhs, const U& rhs) {
+    return rhs * lhs;
+}
+
 template<typename T, typename U>
 void operator+=(T& lhs, const U& rhs) {
     lhs = lhs + rhs;

--- a/lidar/src/deflection.cpp
+++ b/lidar/src/deflection.cpp
@@ -30,10 +30,13 @@ Degree calculate_deflection_component(const SensorReading& reading) {
     double weight = thresh - reading.distance.as_int();
     weight /= thresh;
 
-    // invert the angle and that's the direction our robot should be going
-    // in (possible because 0° is directly forward) 
-    Degree direction = -reading.angle;
+    // try to go 90° away from the problem direction
+    Degree direction = reading.angle >= 0 ?
+        reading.angle - 90 : 90 - reading.angle;
 
+    // scale that angle down by the weight (if the object is further away,
+    // we don't need to take as drastic measures to avoid it as if it were
+    // closer)
     return weight * direction;
 }
 

--- a/lidar/src/deflection.cpp
+++ b/lidar/src/deflection.cpp
@@ -1,6 +1,6 @@
-#include <cmath>
 #include <cassert>
 #include <ros/ros.h>
+#include <math.hpp>
 #include <deflection.hpp>
 
 /**
@@ -37,28 +37,6 @@ double calculate_deflection_component(const SensorReading& reading) {
     }
 
     return severity * direction;
-}
-
-double rad2deg(double radians) {
-    double degrees = radians * 180 / 3.14159; // close enough
-
-    // rotate the coordinate system so that 0 is the front of the robot
-    // then positive should be ccw (i.e. the robot's left)
-    // and negative should bw cw (i.e. the robot's right)
-
-    if (degrees < 0) {
-        degrees += 180;
-    } else {
-        degrees -= 180;
-    }
-
-    assert(degrees > -181.0);
-    assert(degrees < 180.0);
-    return degrees;
-}
-
-double deg2rad(double degrees) {
-    return degrees * 3.14159 / 180;
 }
 
 double weight_for(int angle) {

--- a/lidar/src/main.cpp
+++ b/lidar/src/main.cpp
@@ -7,16 +7,16 @@
 ros::Publisher* publisher = nullptr;
 
 void on_lidar_message(const sensor_msgs::LaserScan::ConstPtr& message) {
-    double deflection = calculate_deflection(message);
+    Degree deflection = calculate_deflection(message);
 
     // for large angles we should report the changes we're making
     if (deflection >= 1.0 || deflection <= -1.0) {
-        ROS_INFO("Deflecting by %f°", deflection);
+        ROS_INFO("Deflecting by %f°", deflection.as_double());
     }
 
     // respond with a 64-bit float telling by how many radians we should deflect
     std_msgs::Float64 msg;
-    msg.data = deg2rad(deflection); 
+    msg.data = deflection.as_radian().as_double(); 
     publisher->publish(msg);
 }
 

--- a/lidar/src/main.cpp
+++ b/lidar/src/main.cpp
@@ -2,6 +2,7 @@
 #include <std_msgs/Float64.h>
 #include <sensor_msgs/LaserScan.h>
 #include <deflection.hpp>
+#include <math.hpp>
 
 ros::Publisher* publisher = nullptr;
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -94,6 +94,42 @@ Degree Radian::as_degree() const {
 double Radian::as_double() const { return m_inner; }
 
 //
+// Centimeter Implementation
+//
+
+Centimeter::Centimeter(double value) : m_inner{value} {
+    assert(value >= 0);
+}
+
+Centimeter Centimeter::operator+(const Centimeter& other) const { 
+    return Centimeter{m_inner + other.m_inner}; 
+}
+Centimeter Centimeter::operator-(const Centimeter& other) const { 
+    return Centimeter{m_inner - other.m_inner}; 
+}
+
+Centimeter Centimeter::operator*(double scalar) const { 
+    return Centimeter{scalar * m_inner}; 
+}
+Centimeter Centimeter::operator/(double scalar) const { 
+    return Centimeter{scalar / m_inner}; 
+}
+
+bool Centimeter::operator<(const Centimeter& other) const {
+    return m_inner < other.m_inner;
+}
+bool Centimeter::operator>(const Centimeter& other) const {
+    return m_inner > other.m_inner;
+}
+bool Centimeter::operator==(const Centimeter& other) const {
+    return m_inner == other.m_inner;
+}
+
+double Centimeter::as_double() const { 
+    return m_inner;
+}
+
+//
 // Conversion
 //
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -9,7 +9,11 @@ constexpr double RADIAN_TO_DEGREE_FACTOR = 180 / PI;
 // Degree Implementation
 //
 
-Degree::Degree(int value) : m_inner{value % 180} {
+Degree::Degree(double value) {
+    auto integral_part = static_cast<long long int>(value);
+    auto fraction_part = value - integral_part;
+    m_inner = (integral_part % 180) + fraction_part;
+
     assert(value >= -180);
     assert(value <= 180);
 }
@@ -22,10 +26,10 @@ Degree Degree::operator-(const Degree& other) const {
 }
 
 Degree Degree::operator*(double scalar) const { 
-    return Degree{static_cast<int>(scalar * m_inner)}; 
+    return Degree{scalar * m_inner}; 
 }
 Degree Degree::operator/(double scalar) const { 
-    return Degree{static_cast<int>(scalar / m_inner)}; 
+    return Degree{scalar / m_inner}; 
 }
 
 bool Degree::operator<(const Degree& other) const {
@@ -34,14 +38,11 @@ bool Degree::operator<(const Degree& other) const {
 bool Degree::operator>(const Degree& other) const {
     return m_inner > other.m_inner;
 }
-bool Degree::operator==(const Degree& other) const {
-    return m_inner == other.m_inner;
-}
 
 Radian Degree::as_radian() const { 
     return Radian{m_inner / RADIAN_TO_DEGREE_FACTOR};
 }
-int Degree::as_int() const { 
+double Degree::as_double() const { 
     return m_inner;
 }
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -38,6 +38,9 @@ bool Degree::operator<(const Degree& other) const {
 bool Degree::operator>(const Degree& other) const {
     return m_inner > other.m_inner;
 }
+bool Degree::operator==(const Degree& other) const {
+    return m_inner == other.m_inner;
+}
 
 Radian Degree::as_radian() const { 
     return Radian{m_inner / RADIAN_TO_DEGREE_FACTOR};
@@ -75,8 +78,18 @@ Radian Radian::operator/(double scalar) const {
     return Radian{m_inner / scalar};
 }
 
+bool Radian::operator<(const Radian& other) const {
+    return m_inner < other.m_inner;
+}
+bool Radian::operator>(const Radian& other) const {
+    return m_inner > other.m_inner;
+}
+bool Radian::operator==(const Radian& other) const {
+    return m_inner == other.m_inner;
+}
+
 Degree Radian::as_degree() const { 
-    return Degree{static_cast<int>(m_inner * RADIAN_TO_DEGREE_FACTOR)};
+    return Degree{m_inner * RADIAN_TO_DEGREE_FACTOR};
 }
 double Radian::as_double() const { return m_inner; }
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -2,6 +2,87 @@
 #include <cmath>
 #include <math.hpp>
 
+constexpr double PI = 3.14159;
+constexpr double RADIAN_TO_DEGREE_FACTOR = 180 / PI;
+
+//
+// Degree Implementation
+//
+
+Degree::Degree(int value) : m_inner{value % 180} {
+    assert(value >= -180);
+    assert(value <= 180);
+}
+
+Degree Degree::operator+(const Degree& other) const { 
+    return Degree{m_inner + other.m_inner}; 
+}
+Degree Degree::operator-(const Degree& other) const { 
+    return Degree{m_inner - other.m_inner}; 
+}
+
+Degree Degree::operator*(double scalar) const { 
+    return Degree{static_cast<int>(scalar * m_inner)}; 
+}
+Degree Degree::operator/(double scalar) const { 
+    return Degree{static_cast<int>(scalar / m_inner)}; 
+}
+
+bool Degree::operator<(const Degree& other) const {
+    return m_inner < other.m_inner;
+}
+bool Degree::operator>(const Degree& other) const {
+    return m_inner > other.m_inner;
+}
+bool Degree::operator==(const Degree& other) const {
+    return m_inner == other.m_inner;
+}
+
+Radian Degree::as_radian() const { 
+    return Radian{m_inner / RADIAN_TO_DEGREE_FACTOR};
+}
+int Degree::as_int() const { 
+    return m_inner;
+}
+
+//
+// Radian Implementation 
+//
+
+Radian::Radian(double value) : m_inner{value} {
+    auto integral_part = static_cast<long long int>(value);
+    auto fraction_part = value - integral_part;
+    
+    integral_part %= 180;
+    m_inner = integral_part + fraction_part;
+
+    assert(value >= -PI);
+    assert(value <= PI);
+}
+
+Radian Radian::operator+(const Radian& other) const {
+    return Radian{m_inner + other.m_inner};
+}
+Radian Radian::operator-(const Radian& other) const {
+    return Radian{m_inner - other.m_inner};
+}
+
+Radian Radian::operator*(double scalar) const {
+    return Radian{m_inner * scalar};
+}
+Radian Radian::operator/(double scalar) const {
+    return Radian{m_inner / scalar};
+}
+
+Degree Radian::as_degree() const { 
+    return Degree{static_cast<int>(m_inner * RADIAN_TO_DEGREE_FACTOR)};
+}
+double Radian::as_double() const { return m_inner; }
+
+//
+// Conversion
+//
+
 double rad2deg(double radians) {
     double degrees = radians * 180 / 3.14159; // close enough
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -21,8 +21,8 @@ Degree::Degree(double value) {
 Degree Degree::operator+(const Degree& other) const { 
     return Degree{m_inner + other.m_inner}; 
 }
-Degree Degree::operator-(const Degree& other) const { 
-    return Degree{m_inner - other.m_inner}; 
+Degree Degree::operator-() const { 
+    return Degree{-m_inner}; 
 }
 
 Degree Degree::operator*(double scalar) const { 
@@ -67,8 +67,8 @@ Radian::Radian(double value) : m_inner{value} {
 Radian Radian::operator+(const Radian& other) const {
     return Radian{m_inner + other.m_inner};
 }
-Radian Radian::operator-(const Radian& other) const {
-    return Radian{m_inner - other.m_inner};
+Radian Radian::operator-() const {
+    return Radian{-m_inner};
 }
 
 Radian Radian::operator*(double scalar) const {
@@ -97,7 +97,7 @@ double Radian::as_double() const { return m_inner; }
 // Centimeter Implementation
 //
 
-Centimeter::Centimeter(double value) : m_inner{value} {
+Centimeter::Centimeter(int value) : m_inner{value} {
     assert(value >= 0);
 }
 
@@ -108,10 +108,10 @@ Centimeter Centimeter::operator-(const Centimeter& other) const {
     return Centimeter{m_inner - other.m_inner}; 
 }
 
-Centimeter Centimeter::operator*(double scalar) const { 
+Centimeter Centimeter::operator*(int scalar) const { 
     return Centimeter{scalar * m_inner}; 
 }
-Centimeter Centimeter::operator/(double scalar) const { 
+Centimeter Centimeter::operator/(int scalar) const { 
     return Centimeter{scalar / m_inner}; 
 }
 
@@ -125,7 +125,7 @@ bool Centimeter::operator==(const Centimeter& other) const {
     return m_inner == other.m_inner;
 }
 
-double Centimeter::as_double() const { 
+int Centimeter::as_int() const { 
     return m_inner;
 }
 

--- a/lidar/src/math.cpp
+++ b/lidar/src/math.cpp
@@ -1,0 +1,26 @@
+#include <cassert>
+#include <cmath>
+#include <math.hpp>
+
+double rad2deg(double radians) {
+    double degrees = radians * 180 / 3.14159; // close enough
+
+    // rotate the coordinate system so that 0 is the front of the robot
+    // then positive should be ccw (i.e. the robot's left)
+    // and negative should bw cw (i.e. the robot's right)
+
+    if (degrees < 0) {
+        degrees += 180;
+    } else {
+        degrees -= 180;
+    }
+
+    assert(degrees > -181.0);
+    assert(degrees < 180.0);
+    return degrees;
+}
+
+double deg2rad(double degrees) {
+    return degrees * 3.14159 / 180;
+}
+


### PR DESCRIPTION
This introduces the `Radian`, `Degree`, and `Centimeter` datatypes as wrappers for `double`, `double`, and `int`, respectively. The benefit of these is that now the type serves as documentation for what the data contains. These types also prevent you from making simple mistakes like trying to add angles measured in radians and degrees without realizing it.